### PR TITLE
feat: added option to use generated or external ssh key/password

### DIFF
--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -1,0 +1,78 @@
+To authenticate to the Virtual machine it is possible to use either SSH-keys or password for Linux VM's and password for Windows VM's.
+This module allows flexibility in configuring virtual machines by either generating passwords and SSH keys internally or allowing users to bring their own.
+
+## Using Internally Generated Password or SSH Key
+When using the internally generated password (default for Windows) or SSH keys (default for Linux), you can simply provide the Key Vault ID where the secrets will be stored in your configuration. For example:
+
+```hcl
+module "vm-linux-ssh" {
+  source = "cloudnationhq/vm/azure"
+  version = "~> 1.3.1"
+
+  naming     = local.naming
+  depends_on = [module.kv]
+
+  instance = {
+    name          = module.naming.linux_virtual_machine.name
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+    type          = "linux"
+
+    interfaces = {
+      int = { subnet = module.network.subnets.int.id }
+    }
+
+    keyvault_id = module.kv.vault.id
+  }
+}
+```
+## Bringing Your Own Password or SSH Key
+If you want to bring your own password or SSH key, you can set these as a property instead. For example:
+
+```hcl
+module "vm-linux-ssh" {
+  source = "cloudnationhq/vm/azure"
+  version = "~> 1.3.1"
+
+  naming     = local.naming
+  depends_on = [module.kv]
+
+  instance = {
+    name          = module.naming.linux_virtual_machine.name
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+    type          = "linux"
+
+    interfaces = {
+      int = { subnet = module.network.subnets.int.id }
+    }
+
+    username   = "linux-admin" ## default is "adminuser" if not set
+    public_key = module.kv.tls_public_keys.vm-linux-demo-dev-key.value
+  }
+}
+```
+
+```hcl
+module "vm-linux-password" {
+  source = "cloudnationhq/vm/azure"
+  version = "~> 1.3.1"
+
+  naming     = local.naming
+  depends_on = [module.kv]
+
+  instance = {
+    name          = module.naming.linux_virtual_machine.name
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+    type          = "linux"
+
+    interfaces = {
+      int = { subnet = module.network.subnets.int.id }
+    }
+
+    username = "linux-admin" ## default is "adminuser" if not set
+    password = module.kv.secrets.vm-linux-demo-dev-password.value
+  }
+}
+```

--- a/examples/authentication/locals.tf
+++ b/examples/authentication/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  naming = {
+    # lookup outputs to have consistent naming
+    for type in local.naming_types : type => lookup(module.naming, type).name
+  }
+
+  naming_types = ["subnet", "network_security_group", "key_vault_secret", "network_interface", "managed_disk", "user_assigned_identity"]
+}

--- a/examples/authentication/main.tf
+++ b/examples/authentication/main.tf
@@ -49,17 +49,17 @@ module "kv" {
 
     secrets = {
       tls_keys = {
-        vm-linux-demo-dev-key = {
+        vm-linux-key = {
           algorithm = "RSA"
           key_size  = 2048
         }
       }
       random_string = {
-        vm-linux-demo-dev-password = {
+        vm-linux-password = {
           length  = 24
           special = false
         }
-        vm-windows-demo-dev-password = {
+        vm-windows-password = {
           length  = 24
           special = false
         }
@@ -76,17 +76,17 @@ module "vm-linux-ssh" {
   depends_on = [module.kv]
 
   instance = {
-    name          = module.naming.linux_virtual_machine.name
+    name          = "${module.naming.linux_virtual_machine.name}-01"
     location      = module.rg.groups.demo.location
     resourcegroup = module.rg.groups.demo.name
     type          = "linux"
 
     interfaces = {
-      int = { subnet = module.network.subnets.int.id }
+      int1 = { subnet = module.network.subnets.int.id }
     }
 
     username   = "linux-admin" ## default is "adminuser" if not set
-    public_key = module.kv.tls_public_keys.vm-linux-demo-dev-key.value
+    public_key = module.kv.tls_public_keys.vm-linux-key.value
   }
 }
 
@@ -98,17 +98,17 @@ module "vm-linux-password" {
   depends_on = [module.kv]
 
   instance = {
-    name          = module.naming.linux_virtual_machine.name
+    name          = "${module.naming.linux_virtual_machine.name}-02"
     location      = module.rg.groups.demo.location
     resourcegroup = module.rg.groups.demo.name
     type          = "linux"
 
     interfaces = {
-      int = { subnet = module.network.subnets.int.id }
+      int2 = { subnet = module.network.subnets.int.id }
     }
 
     username = "linux-admin" ## default is "adminuser" if not set
-    password = module.kv.secrets.vm-linux-demo-dev-password.value
+    password = module.kv.secrets.vm-linux-password.value
   }
 }
 
@@ -120,16 +120,16 @@ module "vm-windows-password" {
   depends_on = [module.kv]
 
   instance = {
-    name          = module.naming.windows_virtual_machine.name
+    name          = "${module.naming.windows_virtual_machine.name}-03"
     location      = module.rg.groups.demo.location
     resourcegroup = module.rg.groups.demo.name
     type          = "windows"
 
     interfaces = {
-      int = { subnet = module.network.subnets.int.id }
+      int3 = { subnet = module.network.subnets.int.id }
     }
 
     username = "windows-admin" ## default is "adminuser" if not set
-    password = module.kv.secrets.vm-windows-demo-dev-password.value
+    password = module.kv.secrets.vm-windows-password.value
   }
 }

--- a/examples/authentication/main.tf
+++ b/examples/authentication/main.tf
@@ -1,0 +1,135 @@
+module "naming" {
+  source  = "cloudnationhq/naming/azure"
+  version = "~> 0.1"
+
+  suffix = ["demo", "dev"]
+}
+
+module "rg" {
+  source  = "cloudnationhq/rg/azure"
+  version = "~> 0.1"
+
+  groups = {
+    demo = {
+      name   = module.naming.resource_group.name
+      region = "westeurope"
+    }
+  }
+}
+
+module "network" {
+  source  = "cloudnationhq/vnet/azure"
+  version = "~> 1.0"
+
+  naming = local.naming
+
+  vnet = {
+    name          = module.naming.virtual_network.name
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+    cidr          = ["10.18.0.0/16"]
+
+    subnets = {
+      int = { cidr = ["10.18.1.0/24"] }
+      mgt = { cidr = ["10.18.2.0/24"] }
+    }
+  }
+}
+
+module "kv" {
+  source  = "cloudnationhq/kv/azure"
+  version = "~> 0.1"
+
+  naming = local.naming
+
+  vault = {
+    name          = module.naming.key_vault.name_unique
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+
+    secrets = {
+      tls_keys = {
+        vm-linux-demo-dev-key = {
+          algorithm = "RSA"
+          key_size  = 2048
+        }
+      }
+      random_string = {
+        vm-linux-demo-dev-password = {
+          length  = 24
+          special = false
+        }
+        vm-windows-demo-dev-password = {
+          length  = 24
+          special = false
+        }
+      }
+    }
+  }
+}
+
+module "vm-linux-ssh" {
+  source = "../.."
+  # version = "~> 0.1"
+
+  naming     = local.naming
+  depends_on = [module.kv]
+
+  instance = {
+    name          = module.naming.linux_virtual_machine.name
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+    type          = "linux"
+
+    interfaces = {
+      int = { subnet = module.network.subnets.int.id }
+    }
+
+    username   = "linux-admin" ## default is "adminuser" if not set
+    public_key = module.kv.tls_public_keys.vm-linux-demo-dev-key.value
+  }
+}
+
+module "vm-linux-password" {
+  source = "../.."
+  # version = "~> 0.1"
+
+  naming     = local.naming
+  depends_on = [module.kv]
+
+  instance = {
+    name          = module.naming.linux_virtual_machine.name
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+    type          = "linux"
+
+    interfaces = {
+      int = { subnet = module.network.subnets.int.id }
+    }
+
+    username = "linux-admin" ## default is "adminuser" if not set
+    password = module.kv.secrets.vm-linux-demo-dev-password.value
+  }
+}
+
+module "vm-windows-password" {
+  source = "../.."
+  # version = "~> 0.1"
+
+  naming     = local.naming
+  depends_on = [module.kv]
+
+  instance = {
+    name          = module.naming.windows_virtual_machine.name
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+    type          = "windows"
+
+    interfaces = {
+      int = { subnet = module.network.subnets.int.id }
+    }
+
+    username = "windows-admin" ## default is "adminuser" if not set
+    password = module.kv.secrets.vm-windows-demo-dev-password.value
+  }
+}

--- a/examples/authentication/main.tf
+++ b/examples/authentication/main.tf
@@ -133,4 +133,3 @@ module "vm-windows-password" {
     password = module.kv.secrets.vm-windows-password.value
   }
 }
-

--- a/examples/authentication/main.tf
+++ b/examples/authentication/main.tf
@@ -69,8 +69,8 @@ module "kv" {
 }
 
 module "vm-linux-ssh" {
-  source = "../.."
-  # version = "~> 0.1"
+  source  = "cloudnationhq/vm/azure"
+  version = "~> 1.3.1"
 
   naming     = local.naming
   depends_on = [module.kv]
@@ -91,8 +91,8 @@ module "vm-linux-ssh" {
 }
 
 module "vm-linux-password" {
-  source = "../.."
-  # version = "~> 0.1"
+  source  = "cloudnationhq/vm/azure"
+  version = "~> 1.3.1"
 
   naming     = local.naming
   depends_on = [module.kv]
@@ -113,8 +113,8 @@ module "vm-linux-password" {
 }
 
 module "vm-windows-password" {
-  source = "../.."
-  # version = "~> 0.1"
+  source  = "cloudnationhq/vm/azure"
+  version = "~> 1.3.1"
 
   naming     = local.naming
   depends_on = [module.kv]

--- a/examples/authentication/main.tf
+++ b/examples/authentication/main.tf
@@ -133,3 +133,4 @@ module "vm-windows-password" {
     password = module.kv.secrets.vm-windows-password.value
   }
 }
+

--- a/examples/authentication/terraform.tf
+++ b/examples/authentication/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.61"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -53,9 +53,9 @@ module "vm" {
   source = "../.."
   # version = "~> 0.1"
 
-  keyvault_id = module.kv.vault.id
-  naming      = local.naming
-  depends_on  = [module.kv]
+  keyvault   = module.kv.vault.id
+  naming     = local.naming
+  depends_on = [module.kv]
 
   instance = {
     name          = module.naming.linux_virtual_machine.name

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -50,18 +50,17 @@ module "kv" {
 }
 
 module "vm" {
-  source  = "cloudnationhq/vm/azure"
-  version = "~> 0.1"
+  source = "../.."
+  # version = "~> 0.1"
 
-  keyvault   = module.kv.vault.id
-  naming     = local.naming
-  depends_on = [module.kv]
+  keyvault_id = module.kv.vault.id
+  naming      = local.naming
+  depends_on  = [module.kv]
 
   instance = {
     name          = module.naming.linux_virtual_machine.name
     location      = module.rg.groups.demo.location
     resourcegroup = module.rg.groups.demo.name
-    keyvault      = module.kv.vault.id
     type          = "linux"
 
     interfaces = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -50,8 +50,8 @@ module "kv" {
 }
 
 module "vm" {
-  source = "../.."
-  # version = "~> 0.1"
+  source  = "cloudnationhq/vm/azure"
+  version = "~> 1.3.1"
 
   keyvault   = module.kv.vault.id
   naming     = local.naming

--- a/examples/custom-data/main.tf
+++ b/examples/custom-data/main.tf
@@ -52,7 +52,7 @@ module "kv" {
 
 module "vm" {
   source  = "cloudnationhq/vm/azure"
-  version = "~> 0.1"
+  version = "~> 1.3.1"
 
   keyvault   = module.kv.vault.id
   naming     = local.naming

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -52,7 +52,7 @@ module "kv" {
 
 module "vm" {
   source  = "cloudnationhq/vm/azure"
-  version = "~> 0.1"
+  version = "~> 1.3.1"
 
   keyvault   = module.kv.vault.id
   naming     = local.naming

--- a/examples/extensions/main.tf
+++ b/examples/extensions/main.tf
@@ -50,7 +50,7 @@ module "kv" {
 
 module "vm" {
   source  = "cloudnationhq/vm/azure"
-  version = "~> 0.1"
+  version = "~> 1.3.1"
 
   keyvault   = module.kv.vault.id
   naming     = local.naming

--- a/examples/multiple-nics/main.tf
+++ b/examples/multiple-nics/main.tf
@@ -51,7 +51,7 @@ module "kv" {
 
 module "vm" {
   source  = "cloudnationhq/vm/azure"
-  version = "~> 0.1"
+  version = "~> 1.3.1"
 
   keyvault   = module.kv.vault.id
   naming     = local.naming

--- a/examples/windows/main.tf
+++ b/examples/windows/main.tf
@@ -50,7 +50,7 @@ module "kv" {
 
 module "vm" {
   source  = "cloudnationhq/vm/azure"
-  version = "~> 0.1"
+  version = "~> 1.3.1"
 
   keyvault   = module.kv.vault.id
   naming     = local.naming

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
   location                        = coalesce(lookup(var.instance, "location", null), var.location)
   size                            = try(var.instance.size, "Standard_D2s_v3")
   admin_username                  = try(var.instance.username, "adminuser")
-  admin_password                  = length(lookup(var.instance, "password", {})) > 0 ? var.instance.password : azurerm_key_vault_secret.secret[var.instance.name].value
+  admin_password                  = try(var.instance.password, null) != null ? var.instance.password : try(var.instance.public_key, null) == null ? azurerm_key_vault_secret.secret[var.instance.name].value : null
   license_type                    = try(var.instance.license_type, null)
   allow_extension_operations      = try(var.instance.allow_extension_operations, true)
   availability_set_id             = try(var.instance.availability_set, null)
@@ -53,9 +53,13 @@ resource "azurerm_linux_virtual_machine" "vm" {
     azurerm_network_interface.nic["${intf.vm_name}-${intf.interface_key}"].id
   ]
 
-  admin_ssh_key {
-    username   = try(var.instance.username, "adminuser")
-    public_key = length(lookup(var.instance, "public_key", {})) == 0 ? tls_private_key.tls_key[var.instance.name].public_key_openssh : var.instance.public_key
+  dynamic "admin_ssh_key" {
+    for_each = try(var.instance.public_key, null) != null ? [1] : []
+    content {
+      username = try(var.instance.username, "adminuser")
+      public_key = try(var.instance.public_key, null) != null ? var.instance.public_key : try(
+      var.instance.password, null) == null ? tls_private_key.tls_key[var.instance.name].public_key_openssh : null
+    }
   }
 
   os_disk {
@@ -99,35 +103,29 @@ resource "azurerm_linux_virtual_machine" "vm" {
 # secrets
 resource "tls_private_key" "tls_key" {
   # workaround, keys used in for each must be known at plan time
-  for_each = var.instance.type == "linux" && lookup(
-    var.instance, "public_key", {}) == {} ? {
-    (var.instance.name) = true
-  } : {}
+  for_each = var.instance.type == "linux" && lookup(var.instance, "public_key", {}) == {} && lookup(
+  var.instance, "password", {}) == {} ? { (var.instance.name) = true } : {}
 
   algorithm = try(var.instance.encryption.algorithm, "RSA")
   rsa_bits  = try(var.instance.encryption.rsa_bits, 4096)
 }
 
 resource "azurerm_key_vault_secret" "tls_public_key_secret" {
-  for_each = var.instance.type == "linux" && lookup(
-    var.instance, "public_key", {}) == {} ? {
-    (var.instance.name) = true
-  } : {}
+  for_each = var.instance.type == "linux" && lookup(var.instance, "public_key", {}) == {} && lookup(
+  var.instance, "password", {}) == {} ? { (var.instance.name) = true } : {}
 
   name         = format("%s-%s-%s", "kvs", var.instance.name, "pub")
   value        = tls_private_key.tls_key[var.instance.name].public_key_openssh
-  key_vault_id = var.keyvault_id
+  key_vault_id = var.keyvault
 }
 
 resource "azurerm_key_vault_secret" "tls_private_key_secret" {
-  for_each = var.instance.type == "linux" && lookup(
-    var.instance, "public_key", {}) == {} ? {
-    (var.instance.name) = true
-  } : {}
+  for_each = var.instance.type == "linux" && lookup(var.instance, "public_key", {}) == {} && lookup(
+  var.instance, "password", {}) == {} ? { (var.instance.name) = true } : {}
 
   name         = format("%s-%s-%s", "kvs", var.instance.name, "priv")
   value        = tls_private_key.tls_key[var.instance.name].private_key_pem
-  key_vault_id = var.keyvault_id
+  key_vault_id = var.keyvault
 }
 
 # windows vm
@@ -232,10 +230,8 @@ resource "azurerm_windows_virtual_machine" "vm" {
 
 resource "random_password" "password" {
   # workaround, keys used in for each must be known at plan time
-  for_each = lookup(
-    var.instance, "password", {}) == {} ? {
-    (var.instance.name) = true
-  } : {}
+  for_each = lookup(var.instance, "password", {}) == {} && lookup(var.instance, "public_key", {}) == {} ? {
+  (var.instance.name) = true } : {}
 
   length      = 24
   special     = true
@@ -246,14 +242,12 @@ resource "random_password" "password" {
 }
 
 resource "azurerm_key_vault_secret" "secret" {
-  for_each = lookup(
-    var.instance, "password", {}) == {} ? {
-    (var.instance.name) = true
-  } : {}
+  for_each = lookup(var.instance, "password", {}) == {} && lookup(var.instance, "public_key", {}) == {} ? {
+  (var.instance.name) = true } : {}
 
   name         = format("%s-%s", "kvs", var.instance.name)
   value        = random_password.password[var.instance.name].result
-  key_vault_id = var.keyvault_id
+  key_vault_id = var.keyvault
 }
 
 # interfaces

--- a/variables.tf
+++ b/variables.tf
@@ -14,10 +14,10 @@ variable "instance" {
       )
       ) || (
       var.instance.type == "linux" && (
-        !can(var.instance.secrets) || can(var.instance.secrets.public_key)
+        !can(var.instance.secrets) || can(var.instance.secrets.public_key || can(var.instance.secrets.password))
       )
     )
-    error_message = "For Windows instances, 'secrets' must contain 'password'. For Linux instances, 'secrets' must contain 'public_key'."
+    error_message = "For Windows instances, 'secrets' must contain 'password'. For Linux instances, 'secrets' must contain 'public_key' or 'password'."
   }
 }
 
@@ -27,9 +27,10 @@ variable "naming" {
   default     = {}
 }
 
-variable "keyvault" {
+variable "keyvault_id" {
   description = "keyvault to store secrets"
   type        = string
+  default     = null
 }
 
 variable "location" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,8 +27,8 @@ variable "naming" {
   default     = {}
 }
 
-variable "keyvault_id" {
-  description = "keyvault to store secrets"
+variable "keyvault" {
+  description = "keyvault id to store secrets"
   type        = string
   default     = null
 }


### PR DESCRIPTION
- Updated versions of examples
- Added new example with readme for different type of authentications (ssh key vs password) and
whether to generate the ssh_key or password from within the module or provide it externally (bring your own ssh key) from another resource or module.