### PR TITLE
feat: added dynamic ip_configuration block to interfaces

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,7 @@ locals {
       dns_servers                   = try(nic.dns_servers, [])
       enable_accelerated_networking = try(nic.enable_accelerated_networking, false)
       enable_ip_forwarding          = try(nic.enable_ip_forwarding, false)
-      subnet_id                     = nic.subnet
+      subnet_id                     = try(nic.subnet_id, nic.subnet)
       ip_config_name                = try(nic.ip_config_name, "ipconfig")
       private_ip_address_allocation = try(nic.private_ip_address_allocation, "Dynamic")
       private_ip_address            = try(nic.private_ip_address, null)
@@ -21,6 +21,20 @@ locals {
       tags                          = try(nic.tags, var.tags, null)
       resourcegroup                 = coalesce(lookup(var.instance, "resourcegroup", null), var.resourcegroup)
       location                      = coalesce(lookup(var.instance, "location", null), var.location)
+      ip_configurations = flatten([
+        for ip_config_key, ip_config in try(nic.ip_configurations, {}) : {
+
+          ip_config_key                       = ip_config_key
+          name                                = try(ip_config.name, join("-", [var.naming.ip_configuration, ip_config_key]))
+          private_ip_address_allocation       = try(ip_config.private_ip_address_allocation, "Dynamic")
+          private_ip_address                  = try(ip_config.private_ip_address, null)
+          subnet_id                           = try(ip_config.subnet_id, null)
+          public_ip_address_id                = try(ip_config.public_ip_address_id, null)
+          load_balancer_backend_address_pools = try(ip_config.load_balancer_backend_address_pools, [])
+          load_balancer_inbound_nat_rules     = try(ip_config.load_balancer_inbound_nat_rules, [])
+          tags                                = try(ip_config.tags, null)
+        }
+      ])
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -276,13 +276,16 @@ resource "azurerm_network_interface" "nic" {
   dns_servers                   = each.value.dns_servers
   tags                          = each.value.tags
 
-  ip_configuration {
-    name                          = each.value.ip_config_name
-    private_ip_address_allocation = each.value.private_ip_address != null ? "Static" : "Dynamic"
-    private_ip_address            = each.value.private_ip_address
-    public_ip_address_id          = each.value.public_ip_address_id
-    subnet_id                     = each.value.subnet_id
-    private_ip_address_version    = each.value.private_ip_address_version
+  dynamic "ip_configuration" {
+    for_each = each.value.ip_configurations
+    content {
+      name                          = ip_configuration.value.name
+      private_ip_address_allocation = ip_configuration.value.private_ip_address_allocation != null ? "Static" : "Dynamic"
+      private_ip_address            = ip_configuration.value.private_ip_address
+      public_ip_address_id          = ip_configuration.value.public_ip_address_id
+      subnet_id                     = ip_configuration.value.subnet_id
+      private_ip_address_version    = ip_configuration.value.private_ip_address_version
+    }
   }
 }
 


### PR DESCRIPTION
Suggestion on how to make multiple ip_configuration blocks per network interface card. 

Fixes issue #109 

Use this code example in the interfaces block on how to use it:
 
    interfaces = {
      int = {
        subnet                        = module.network_test.subnets.sn1test.id
        name                          = "vmtest02305"
        private_ip_address_allocation = "Dynamic"
        private_ip_address            = "10.18.1.4"
        enable_accelerated_networking = true
        ip_config_name                = "ipconfig1"
        ip_configurations = {
          ipconfig1 = {
            name                          = "ipconfig1"
            private_ip_address_allocation = "Dynamic"
            private_ip_address            = "10.0.0.0"
          }
          ipconfig2 = {
            name                          = "ipconfig2"
            private_ip_address_allocation = "Dynamic"
            private_ip_address            = "10.0.0.2"
          }
        }
      }
      int2 = {
        subnet                        = module.network_test.subnets.sn1test.id
        name                          = "vmtest02305"
        private_ip_address_allocation = "Dynamic"
        private_ip_address            = "10.18.1.4"
        enable_accelerated_networking = true
        ip_config_name                = "ipconfig1"
        ip_configurations = {
          ipconfig1 = {
            name                          = "ipconfig1"
            private_ip_address_allocation = "Dynamic"
            private_ip_address            = "10.0.0.0"
          }
          ipconfig2 = {
            name                          = "ipconfig2"
            private_ip_address_allocation = "Dynamic"
            private_ip_address            = "10.0.0.2"
          }
        }
      }
    }