### PR TITLE
feat: update tls & random provider versions

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -9,12 +9,12 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.5.1"
+      version = "~> 3.6"
     }
 
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 4.0.4"
+      version = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
## Description

The Random version provider is currently set to ~> 3.5.1 and using this module in conjunction with the CAF Enterprise Scale module (latest 6.0.0 version) I have encountered a constraint error due to incompatible provider version specifications.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * Updated version of random & tls providers


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes https://github.com/CloudNationHQ/terraform-azure-sa/issues/83