### PR TITLE
feat: make source image reference fully optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,11 +76,14 @@ resource "azurerm_linux_virtual_machine" "vm" {
     write_accelerator_enabled = try(var.instance.os_disk.write_accelerator_enabled, false)
   }
 
-  source_image_reference {
-    publisher = try(var.instance.image.publisher, "Canonical")
-    offer     = try(var.instance.image.offer, "UbuntuServer")
-    sku       = try(var.instance.image.sku, "18.04-LTS")
-    version   = try(var.instance.image.version, "latest")
+  dynamic "source_image_reference" {
+    for_each = lookup(var.instance, "source_image_id", null) == null ? [1] : []
+    content {
+      publisher = try(var.instance.image.publisher, "Canonical")
+      offer     = try(var.instance.image.offer, "UbuntuServer")
+      sku       = try(var.instance.image.sku, "18.04-LTS")
+      version   = try(var.instance.image.version, "latest")
+    }
   }
 
   dynamic "plan" {
@@ -209,11 +212,14 @@ resource "azurerm_windows_virtual_machine" "vm" {
     name                             = try(var.instance.os_disk.name, null)
   }
 
-  source_image_reference {
-    publisher = try(var.instance.image.publisher, "MicrosoftWindowsServer")
-    offer     = try(var.instance.image.offer, "WindowsServer")
-    sku       = try(var.instance.image.sku, "2022-Datacenter")
-    version   = try(var.instance.image.version, "latest")
+  dynamic "source_image_reference" {
+    for_each = lookup(var.instance, "source_image_id", null) == null ? [1] : []
+    content {
+      publisher = try(var.instance.image.publisher, "MicrosoftWindowsServer")
+      offer     = try(var.instance.image.offer, "WindowsServer")
+      sku       = try(var.instance.image.sku, "2022-Datacenter")
+      version   = try(var.instance.image.version, "latest")
+    }
   }
 
   dynamic "plan" {


### PR DESCRIPTION
The source_image_reference block in the main.tf file has been refactored to use dynamic blocks. This change allows for more flexibility in handling the source image reference based on the value of the var.instance.source_image_id variable. The publisher, offer, sku, and version values are now set based on the var.instance.image object, with default values provided if the object is not present.

## Description
Currently it is not possible to create a VM from a custom image (source_image_id). It is not allowed to use source_image_id and source_image_reference at the same time. The module did not support this since source_image_reference was not dynamic it would always be called and therefore the following error would show:

```
│` Error: Invalid combination of arguments

│ 

│   with module.Infrastructure.module.vm-hallo["vm_muv"].azurerm_windows_virtual_machine.vm["vmmueudev"],

│   on .terraform/modules/Infrastructure.vm-hallo/main.tf line 137, in resource "azurerm_windows_virtual_machine" "vm":

│  137: resource "azurerm_windows_virtual_machine" "vm" {

│ 

│ "source_image_reference": only one of

│ `source_image_id,source_image_reference` can be specified, but

│ `source_image_id,source_image_reference` were specified.
```

The idea of this PR is to perform a lookup for source_image_id in var.instance and set it to null if it doesn't exist. If source_image_id is null or doesn't exist, then source_image_reference is automatically used (it will use the default image from the module or the defined image if specified, just as before). This way, the source_image_reference will not be triggered if source_image_id is specified.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) 

 * `source_image_reference` - added dynamic block which checks if source_image_id exists.


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #127
