### PR TITLE
fix: lifecycle ignore settings on extensions because of AADLoginForWindows null vs. {} mismatch causing endless diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For more information, please see our contribution [guidelines](./CONTRIBUTING.md
 
 MIT Licensed. See [LICENSE](./LICENSE) for full details.
 
-## Reference
+## References
 
 - [Documentation](https://learn.microsoft.com/en-us/azure/virtual-machines/)
 - [Rest Api](https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines)

--- a/main.tf
+++ b/main.tf
@@ -312,6 +312,14 @@ resource "azurerm_virtual_machine_extension" "ext" {
   settings                   = jsonencode(each.value.settings)
   protected_settings         = jsonencode(each.value.protected_settings)
   tags                       = each.value.tags
+
+  # The AADLoginForWindows extension needs JSON "null" for settings, but Azure returns "{}."
+  # This mismatch causes endless diffs, so we ignore settings changes.
+  lifecycle {
+    ignore_changes = [
+      settings,
+    ]
+  }
 }
 
 # data disks


### PR DESCRIPTION
## Description

The AADLoginForWindows extension requires sending a JSON null for its settings property, but Azure’s API always returns an empty object ({}). This mismatch causes Terraform to detect a perpetual in-place update on every plan. By adding ignore_changes on settings, we prevent those endless diffs and stabilize the Terraform configuration.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #168 
