### PR TITLE
fix: revert default value patch mode linux virtual machines and improved availability set iteration

### DIFF
--- a/examples/availability-sets/main.tf
+++ b/examples/availability-sets/main.tf
@@ -11,7 +11,7 @@ module "rg" {
 
   groups = {
     demo = {
-      name     = module.naming.resource_group.name
+      name     = module.naming.resource_group.name_unique
       location = "westeurope"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
   encryption_at_host_enabled      = try(var.instance.encryption_at_host_enabled, false)
   extensions_time_budget          = try(var.instance.extensions_time_budget, null)
   patch_assessment_mode           = try(var.instance.patch_assessment_mode, "ImageDefault")
-  patch_mode                      = try(var.instance.patch_mode, "AutomaticByOS")
+  patch_mode                      = try(var.instance.patch_mode, "ImageDefault")
   priority                        = try(var.instance.priority, "Regular")
   provision_vm_agent              = try(var.instance.provision_vm_agent, true)
   reboot_setting                  = try(var.instance.reboot_setting, null)

--- a/modules/availability-sets/main.tf
+++ b/modules/availability-sets/main.tf
@@ -1,6 +1,6 @@
 # availability sets
 resource "azurerm_availability_set" "avail" {
-  for_each = try(var.availability_sets, {})
+  for_each = var.availability_sets != null ? var.availability_sets : {}
 
   name                         = try(each.value.name, join("-", [var.naming.availability_set, each.key]))
   location                     = try(each.value.location, var.location)
@@ -10,5 +10,7 @@ resource "azurerm_availability_set" "avail" {
   platform_update_domain_count = try(each.value.platform_update_domain_count, 5)
   proximity_placement_group_id = try(each.value.proximity_placement_group_id, null)
 
-  tags = try(each.value.tags, var.tags, {})
+  tags = try(
+    each.value.tags, var.tags, {}
+  )
 }


### PR DESCRIPTION
## Description

This PR reverts the default value patch mode on linux virtual machines and improved availability set iteration

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)