### PR TITLE
fix: change defaults protected settings extensions

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -89,8 +89,8 @@ locals {
       publisher                  = ext.publisher,
       type                       = ext.type,
       type_handler_version       = ext.type_handler_version,
-      settings                   = lookup(ext, "settings", {}),
-      protected_settings         = lookup(ext, "protected_settings", {}),
+      settings                   = lookup(ext, "settings", null),
+      protected_settings         = lookup(ext, "protected_settings", null),
       auto_upgrade_minor_version = try(ext.auto_upgrade_minor_version, true)
       tags                       = try(ext.tags, var.tags, null)
     }

--- a/main.tf
+++ b/main.tf
@@ -318,6 +318,7 @@ resource "azurerm_virtual_machine_extension" "ext" {
   lifecycle {
     ignore_changes = [
       settings,
+      protected_settings
     ]
   }
 }


### PR DESCRIPTION
## Description

This PR changes defaults for settings and protected settings in extensions

```
  # The AADLoginForWindows extension needs JSON "null" for settings, but Azure returns "{}."
  # This mismatch causes endless diffs, so we ignore settings changes.
  lifecycle {
    ignore_changes = [
      settings,
      protected_settings
    ]
  }
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)