### PR TITLE
fix: fix duplicate interface naming

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,10 +2,9 @@ locals {
   interfaces = [
     for interface_key, nic in var.instance.interfaces : {
 
-      vm_name       = var.instance.name
-      interface_key = interface_key
-      name          = try(nic.name, join("-", [var.naming.network_interface, var.instance.name, interface_key]))
-      # name                           = try(nic.name, join("-", [var.naming.network_interface, interface_key]))
+      vm_name                        = var.instance.name
+      interface_key                  = interface_key
+      name                           = try(nic.name, join("-", [var.naming.network_interface, var.instance.name, interface_key]))
       dns_servers                    = try(nic.dns_servers, [])
       accelerated_networking_enabled = try(nic.accelerated_networking_enabled, false)
       ip_forwarding_enabled          = try(nic.ip_forwarding_enabled, false)

--- a/locals.tf
+++ b/locals.tf
@@ -2,9 +2,10 @@ locals {
   interfaces = [
     for interface_key, nic in var.instance.interfaces : {
 
-      vm_name                        = var.instance.name
-      interface_key                  = interface_key
-      name                           = try(nic.name, join("-", [var.naming.network_interface, interface_key]))
+      vm_name       = var.instance.name
+      interface_key = interface_key
+      name          = try(each.value.name, join("-", [var.instance.name, interface_key]))
+      # name                           = try(nic.name, join("-", [var.naming.network_interface, interface_key]))
       dns_servers                    = try(nic.dns_servers, [])
       accelerated_networking_enabled = try(nic.accelerated_networking_enabled, false)
       ip_forwarding_enabled          = try(nic.ip_forwarding_enabled, false)

--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,7 @@ locals {
 
       vm_name       = var.instance.name
       interface_key = interface_key
-      name          = try(nic.name, join("-", [var.instance.name, interface_key]))
+      name          = try(nic.name, join("-", [var.naming.network_interface, var.instance.name, interface_key]))
       # name                           = try(nic.name, join("-", [var.naming.network_interface, interface_key]))
       dns_servers                    = try(nic.dns_servers, [])
       accelerated_networking_enabled = try(nic.accelerated_networking_enabled, false)

--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,7 @@ locals {
 
       vm_name       = var.instance.name
       interface_key = interface_key
-      name          = try(each.value.name, join("-", [var.instance.name, interface_key]))
+      name          = try(nic.name, join("-", [var.instance.name, interface_key]))
       # name                           = try(nic.name, join("-", [var.naming.network_interface, interface_key]))
       dns_servers                    = try(nic.dns_servers, [])
       accelerated_networking_enabled = try(nic.accelerated_networking_enabled, false)


### PR DESCRIPTION
## Description

This PR fixes the duplicate network interface names

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)