### PR TITLE
fix: update vm extensions settings variable type from map(string) to map(any)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -175,7 +175,7 @@ variable "instance" {
       publisher                   = string
       type                        = string
       type_handler_version        = string
-      settings                    = optional(map(string), {})
+      settings                    = optional(map(any), {})
       protected_settings          = optional(map(string), {})
       auto_upgrade_minor_version  = optional(bool, true)
       automatic_upgrade_enabled   = optional(bool, false)


### PR DESCRIPTION
## Description

Unable to add extensions due to string type definition for extension settings.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #201
