### PR TITLE
fix: replace try with coalesce for availability set attributes

### DIFF
--- a/modules/availability-sets/main.tf
+++ b/modules/availability-sets/main.tf
@@ -2,16 +2,16 @@
 resource "azurerm_availability_set" "avail" {
   for_each = var.availability_sets != null ? var.availability_sets : {}
 
-  location = try(
+  location = coalesce(
     each.value.location, var.location
   )
 
-  resource_group_name = try(
+  resource_group_name = coalesce(
     each.value.resource_group_name, var.resource_group_name
   )
 
-  name = try(
-    each.value.name, join("-", [var.naming.availability_set, each.key])
+  name = coalesce(
+    each.value.name, try(join("-", [var.naming.availability_set, each.key]), null)
   )
 
   managed                      = each.value.managed


### PR DESCRIPTION
## Description

Replaced try() with coalesce() for location, resource_group_name, and name in `azurerm_availability_set`


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_availability_set` - use coalesce instead of try for location, resource_group_name, and name


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #233 
